### PR TITLE
Update swagger-codegen dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-codegen.version>2.1.2-M1</swagger-codegen.version>
+        <swagger-codegen.version>2.1.2</swagger-codegen.version>
     </properties>
 
     <scm>
@@ -76,7 +76,7 @@
             <version>3.4</version>
         </dependency>
         <dependency>
-            <groupId>com.wordnik</groupId>
+            <groupId>io.swagger</groupId>
             <artifactId>swagger-codegen</artifactId>
             <version>${swagger-codegen.version}</version>
         </dependency>

--- a/src/main/java/com/wordnik/swagger/codegen/plugin/CodeGenMojo.java
+++ b/src/main/java/com/wordnik/swagger/codegen/plugin/CodeGenMojo.java
@@ -16,11 +16,14 @@ package com.wordnik.swagger.codegen.plugin;
  * limitations under the License.
  */
 
-import com.wordnik.swagger.codegen.ClientOptInput;
-import com.wordnik.swagger.codegen.ClientOpts;
-import com.wordnik.swagger.codegen.CodegenConfig;
-import com.wordnik.swagger.codegen.DefaultGenerator;
-import com.wordnik.swagger.models.Swagger;
+import java.io.File;
+import java.util.ServiceLoader;
+
+import io.swagger.codegen.ClientOptInput;
+import io.swagger.codegen.ClientOpts;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.DefaultGenerator;
+import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -28,9 +31,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-
-import java.io.File;
-import java.util.ServiceLoader;
 
 import static com.wordnik.swagger.codegen.plugin.AdditionalParams.TEMPLATE_DIR_PARAM;
 


### PR DESCRIPTION
I have experienced some NullPointerExceptions when I have tried to generate client code for a Swagger API V2 JSON file. After updating the dependency from 2.1.2-M1 to the latest release version and the new groupId everything was working as expected.
