### PR TITLE
Update swagger to release version & support config files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-codegen.version>2.1.2-M1</swagger-codegen.version>
+        <swagger-codegen.version>2.1.2</swagger-codegen.version>
     </properties>
 
     <scm>
@@ -76,7 +76,7 @@
             <version>3.4</version>
         </dependency>
         <dependency>
-            <groupId>com.wordnik</groupId>
+            <groupId>io.swagger</groupId>
             <artifactId>swagger-codegen</artifactId>
             <version>${swagger-codegen.version}</version>
         </dependency>
@@ -148,7 +148,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>sign-artifacts</id>

--- a/src/main/java/com/wordnik/swagger/codegen/plugin/CodeGenMojo.java
+++ b/src/main/java/com/wordnik/swagger/codegen/plugin/CodeGenMojo.java
@@ -16,6 +16,9 @@ package com.wordnik.swagger.codegen.plugin;
  * limitations under the License.
  */
 
+import config.Config;
+import config.ConfigParser;
+import io.swagger.codegen.CliOption;
 import io.swagger.codegen.ClientOptInput;
 import io.swagger.codegen.ClientOpts;
 import io.swagger.codegen.CodegenConfig;
@@ -75,6 +78,12 @@ public class CodeGenMojo extends AbstractMojo {
     private boolean addCompileSourceRoot = true;
 
     /**
+     * Location for a configuration file for customisation of the swagger client code generation
+     */
+    @Parameter(name = "configFile")
+    private String configFile;
+
+    /**
      * The project being built.
      */
     @Parameter(readonly = true, required = true, defaultValue = "${project}")
@@ -92,11 +101,27 @@ public class CodeGenMojo extends AbstractMojo {
         }
 
         ClientOptInput input = new ClientOptInput().opts(new ClientOpts()).swagger(swagger);
+
+        if (null != configFile) {
+            applyConfigFileSettings(config);
+        }
+
         input.setConfig(config);
         new DefaultGenerator().opts(input).generate();
 
         if (addCompileSourceRoot) {
             project.addCompileSourceRoot(output.toString());
+        }
+    }
+
+    private void applyConfigFileSettings(final CodegenConfig config) {
+        Config genConfig = ConfigParser.read(configFile);
+        if (null != genConfig) {
+            for (CliOption langCliOption : config.cliOptions()) {
+                if (genConfig.hasOption(langCliOption.getOpt())) {
+                    config.additionalProperties().put(langCliOption.getOpt(), genConfig.getOption(langCliOption.getOpt()));
+                }
+            }
         }
     }
 

--- a/src/main/java/com/wordnik/swagger/codegen/plugin/CodeGenMojo.java
+++ b/src/main/java/com/wordnik/swagger/codegen/plugin/CodeGenMojo.java
@@ -16,11 +16,11 @@ package com.wordnik.swagger.codegen.plugin;
  * limitations under the License.
  */
 
-import com.wordnik.swagger.codegen.ClientOptInput;
-import com.wordnik.swagger.codegen.ClientOpts;
-import com.wordnik.swagger.codegen.CodegenConfig;
-import com.wordnik.swagger.codegen.DefaultGenerator;
-import com.wordnik.swagger.models.Swagger;
+import io.swagger.codegen.ClientOptInput;
+import io.swagger.codegen.ClientOpts;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.DefaultGenerator;
+import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;


### PR DESCRIPTION
I've updated the project to take the swagger-codegen v2.1.2 release and the dependency/package names to match.  There is also a commit to support specifying the location of a config file.  The feature was added via [swagger-codegen issue #616](https://github.com/swagger-api/swagger-codegen/issues/616).
